### PR TITLE
cache „parse error” directory fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ It can also receive webhooks sent by location-aware mobile apps (such as [Locati
         "guestSensorName" : "Guests",
         "webhookEnabled" : false,
         "webhookPort": 51828,
-        "cacheDirectory": "./.node-persist/storage",
+        "cacheDirectory": "./persistent",
         "checkInterval": 10000,
         "ignoreReEnterExitSeconds": 0,
         "people" : [
@@ -79,7 +79,7 @@ It can also receive webhooks sent by location-aware mobile apps (such as [Locati
 | `isGuest`                  | optional, default: false                                                                                                                                                                     |
 | `statusOnly`               | optional, default: false                                                                                                                                                                     |
 | `webhookPort`              | optional, default: 51828                                                                                                                                                                     |
-| `cacheDirectory`           | optional, default: "./.node-persist/storage"                                                                                                                                                 |
+| `cacheDirectory`           | optional, default: "./persistent"                                                                                                                                                 |
 | `checkInterval`            | optional, in milliseconds, default: 10000, if set to -1 than the check mechanism will not be used                                                                                            |
 | `ignoreReEnterExitSeconds` | optional, in minutes, default: 0, if set to 0 than every enter/exit will trigger state change otherwise the state will only change if no re-enter/exit occurs in specified number of seconds |
 | `target`                   | may be either a hostname or IP address                                                                                                                                                       |

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ function PeoplePlatform(log, config){
     this.ignoreReEnterExitSeconds = config["ignoreReEnterExitSeconds"] || 0;
     this.people = config['people'];
     this.storage = require('node-persist');
-    this.storage.initSync({dir:this.cacheDirectory});
+    this.storage.initSync({dir:this.cacheDirectory, forgiveParseErrors: true});
     this.webhookQueue = [];
 }
 


### PR DESCRIPTION
On my configuration the plugin was causing homebridge crash due to „parse error” of the files created by other plugins in /persistent directory.
So I have added an argument to ignore unsupported files so the plugin is working again by default, without need to define different cache manually dir in config, which may be misleading as well due to readme pointing to a depreciated location.